### PR TITLE
✨ SearchResult 페이지 구현

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,0 +1,8 @@
+import { ApolloClient, InMemoryCache } from '@apollo/client';
+
+const client = new ApolloClient({
+  uri: 'https://beta.pokeapi.co/graphql/v1beta',
+  cache: new InMemoryCache(),
+});
+
+export default client;

--- a/src/api/gql/getPokemons.ts
+++ b/src/api/gql/getPokemons.ts
@@ -1,0 +1,51 @@
+import { gql } from '@apollo/client';
+
+const GET_POKEMONS = gql`
+  query pokemonCardsInfoQuery(
+    $limit: Int!
+    $keyword: String!
+    $type: String!
+    $sort: [pokemon_v2_pokemon_order_by!]
+    $lang: String!
+  ) {
+    pokemonCardsInfo: pokemon_v2_pokemon(
+      where: {
+        is_default: { _eq: true }
+        pokemon_v2_pokemontypes: {
+          pokemon_v2_type: {
+            pokemon_v2_typenames: {
+              pokemon_v2_type: { name: { _iregex: $type } }
+            }
+          }
+        }
+        pokemon_v2_pokemonspecy: {
+          pokemon_v2_pokemonspeciesnames: {
+            _and: {
+              name: { _iregex: $keyword }
+              pokemon_v2_language: { name: { _eq: $lang } }
+            }
+          }
+        }
+      }
+      limit: $limit
+      order_by: $sort
+    ) {
+      enName: name
+      id: pokemon_species_id
+      types: pokemon_v2_pokemontypes {
+        type: pokemon_v2_type {
+          name
+        }
+      }
+      specy: pokemon_v2_pokemonspecy {
+        koName: pokemon_v2_pokemonspeciesnames(
+          where: { language_id: { _eq: 3 } }
+        ) {
+          name
+        }
+      }
+    }
+  }
+`;
+
+export default GET_POKEMONS;

--- a/src/api/gql/index.ts
+++ b/src/api/gql/index.ts
@@ -1,0 +1,3 @@
+import GET_POKEMONS from './getPokemons';
+
+export { GET_POKEMONS };

--- a/src/app/compatibility/page.tsx
+++ b/src/app/compatibility/page.tsx
@@ -28,20 +28,20 @@ export default function Compatibility() {
     <div className="flex flex-col items-center mb-16">
       <section className="mx-5 mt-8 mb-12">
         <h2 className="sr-only">필터 선택</h2>
-        <TypeFilters usage="compatibility" lang="kr" />
+        <TypeFilters usage="compatibility" lang="ko" />
       </section>
       <Pokedex className="w-[36.25rem] min-h-[25.5rem] mb-12 bg-cover">
-        <h2 className="sr-only">{`${convertTypeTagName(type, 'kr')} 타입`}</h2>
+        <h2 className="sr-only">{`${convertTypeTagName(type, 'ko')} 타입`}</h2>
         <TypeTag
           usage="compatibility"
           type={type}
           size="polygon"
-          lang="kr"
+          lang="ko"
           className="absolute top-[9rem] left-[5.375rem]"
         />
         <SelectedType
           type={type}
-          lang="kr"
+          lang="ko"
           className="top-[9rem] right-[2.75rem]"
         />
         <Logo
@@ -50,10 +50,10 @@ export default function Compatibility() {
         />
       </Pokedex>
       <div className="flex flex-col gap-5 max-w-[50.5rem] w-full mx-5">
-        <BattleInfo usage="attack" type={type} lang="kr" />
-        <BattleInfo usage="defense" type={type} lang="kr" />
+        <BattleInfo usage="attack" type={type} lang="ko" />
+        <BattleInfo usage="defense" type={type} lang="ko" />
       </div>
-      <CommonButton type="viewCompatibility" lang="kr" className="my-10" />
+      <CommonButton type="viewCompatibility" lang="ko" className="my-10" />
     </div>
   );
 }

--- a/src/app/pokemon/[id]/page.tsx
+++ b/src/app/pokemon/[id]/page.tsx
@@ -4,12 +4,12 @@ import pokemonDefault from '@/mocks/pokemonDefault.json';
 import pokemonException from '@/mocks/pokemonException.json';
 
 export default function Pokemon() {
-  const processed = processDetailInfo(pokemonDefault.data, 'kr');
+  const processed = processDetailInfo(pokemonDefault.data, 'ko');
 
   return (
     <main className="relative mx-5 my-8">
       <h2 className="sr-only">{`${processed.name}의 상세 정보`}</h2>
-      <PokemonInfo pokemonDetailInfo={processed} lang="kr" />
+      <PokemonInfo pokemonDetailInfo={processed} lang="ko" />
       <CatchButton
         size="large"
         isCatched={false}

--- a/src/app/searchresult/layout.tsx
+++ b/src/app/searchresult/layout.tsx
@@ -1,3 +1,7 @@
+'use client';
+
+import { ApolloProvider } from '@apollo/client';
+import client from '@/api/client';
 import { Header } from '@/components';
 
 export default function SearchResultLayout({
@@ -6,9 +10,9 @@ export default function SearchResultLayout({
   children: React.ReactNode;
 }) {
   return (
-    <>
+    <ApolloProvider client={client}>
       <Header />
       <div className="container-page">{children}</div>
-    </>
+    </ApolloProvider>
   );
 }

--- a/src/app/searchresult/page.tsx
+++ b/src/app/searchresult/page.tsx
@@ -1,19 +1,27 @@
+'use client';
+
 import { TypeFilters, Dropdown, PokemonCards } from '@/components';
 import { processCardsInfo } from '@/utils/processCardsInfo';
-import pokemons from '@/mocks/pokemons.json';
+import useSearch from '@/hooks/useSearch';
 
 export default function SearchResult() {
-  const processed = processCardsInfo(pokemons.data.pokemonCardsInfo, 'kr');
+  const { loading, error, pokemonCardsInfo } = useSearch();
+
+  if (loading) return null;
+  if (error) return `Error : ${error}`;
 
   return (
     <>
       <section className="flex flex-col gap-4 mx-5 mt-8 mb-4">
         <h2 className="sr-only">필터 선택</h2>
-        <TypeFilters usage="search" lang="kr" />
+        <TypeFilters usage="search" lang="ko" />
         <Dropdown />
       </section>
       <main>
-        <PokemonCards pokemonCardsInfo={processed} lang="kr" />
+        <PokemonCards
+          pokemonCardsInfo={processCardsInfo(pokemonCardsInfo, 'ko')}
+          lang="ko"
+        />
       </main>
     </>
   );

--- a/src/components/features/BattleInfo.tsx
+++ b/src/components/features/BattleInfo.tsx
@@ -1,5 +1,6 @@
 import { TypeTag } from '@/components';
-import { BATTLE_INFO_TITLES, BATTLE_INFO_CONTENTS } from '@/constants/contents';
+import { BATTLE_INFO_TITLES } from '@/constants/contents';
+import { BATTLE_INFO_VALUES } from '@/constants/values';
 import { DefaultProps, Lang, PokemonType } from '@/types/common';
 
 type InfoUsage = 'attack' | 'defense';
@@ -11,7 +12,7 @@ interface BattleInfoProps extends DefaultProps {
 }
 
 export default function BattleInfo({ usage, type, lang }: BattleInfoProps) {
-  const battleInfo = Object.entries(BATTLE_INFO_CONTENTS[type][usage]).sort(
+  const battleInfo = Object.entries(BATTLE_INFO_VALUES[type][usage]).sort(
     (a, b) => +b[0] - +a[0],
   );
 
@@ -28,7 +29,7 @@ export default function BattleInfo({ usage, type, lang }: BattleInfoProps) {
             key={effect}
             className="flex grow justify-center items-center gap-4 ">
             <h4 className="text-xl text-gray-70 font-bold whitespace-nowrap">
-              {`${effect}${lang === 'kr' ? '배' : 'x'} :`}
+              {`${effect}${lang === 'ko' ? '배' : 'x'} :`}
             </h4>
             <div className="container-type flex-wrap">
               {types.map((type) => (

--- a/src/components/features/PokemonCards/PokemonCard.tsx
+++ b/src/components/features/PokemonCards/PokemonCard.tsx
@@ -27,7 +27,13 @@ export default function PokemonCard({
         />
         <div className="container-type">
           {types.map((type) => (
-            <TypeTag usage="info" type={type} size="large" lang={lang} />
+            <TypeTag
+              key={type}
+              usage="info"
+              type={type}
+              size="large"
+              lang={lang}
+            />
           ))}
         </div>
         <CatchButton

--- a/src/components/features/PokemonCards/PokemonCards.tsx
+++ b/src/components/features/PokemonCards/PokemonCards.tsx
@@ -17,7 +17,11 @@ export default function PokemonCards({
       }>
       <h2 className="sr-only">검색 결과</h2>
       {pokemonCardsInfo.map((pokemonCardInfo) => (
-        <PokemonCard pokemonCardInfo={pokemonCardInfo} lang={lang} />
+        <PokemonCard
+          key={pokemonCardInfo.id}
+          pokemonCardInfo={pokemonCardInfo}
+          lang={lang}
+        />
       ))}
     </section>
   );

--- a/src/components/shared/CommonButton.tsx
+++ b/src/components/shared/CommonButton.tsx
@@ -13,16 +13,19 @@ type CommonButtonUsage =
 interface CommonButtonProps extends DefaultProps {
   type: CommonButtonUsage;
   lang: Lang;
+  onClick?: React.MouseEventHandler<HTMLButtonElement>;
 }
 
 export default function CommonButton({
   type,
   lang,
+  onClick,
   className,
 }: CommonButtonProps) {
   return (
     <button
       type="button"
+      onClick={onClick}
       className={twMerge(
         `w-max px-[1.5625rem] py-4 border-[.1875rem] border-black-50 rounded-full text-xl font-bold shadow-inner/top/white drop-shadow-[0_2px_6px_rgba(0,0,0,0.25)] hover:scale-105 transition-all ease-in-out ${COMMON_BUTTON_BG[type]}`,
         type === 'viewAll' && 'px-[1.3125rem] py-3 text-[1.125rem]',

--- a/src/components/shared/PokemonImage.tsx
+++ b/src/components/shared/PokemonImage.tsx
@@ -10,13 +10,13 @@ interface PokemonImageProps extends DefaultProps {
   name: string;
 }
 
-export default async function PokemonImage({
+export default function PokemonImage({
   size,
   id,
   name,
   ...props
 }: PokemonImageProps) {
-  const { imgUrl, format } = await getImageInfo(id);
+  const { imgUrl, format } = getImageInfo(id);
 
   const imgSize = POKEMON_IMAGE_SIZE[format][size];
 
@@ -26,7 +26,8 @@ export default async function PokemonImage({
       alt={`${name}의 모습`}
       width={imgSize}
       height={imgSize}
-      style={{ width: imgSize, height: imgSize }}
+      loading="lazy"
+      style={{ width: imgSize, height: imgSize, objectFit: 'contain' }}
       {...props}
     />
   );

--- a/src/components/shared/SearchInput.tsx
+++ b/src/components/shared/SearchInput.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import { twMerge } from 'tailwind-merge';
 import { DefaultProps } from '@/types/common';
@@ -14,6 +14,7 @@ interface SearchInputProps extends DefaultProps {
 export default function SearchInput({ type, className }: SearchInputProps) {
   const router = useRouter();
   const [keyword, setKeyword] = useState('');
+  const formRef = useRef<HTMLFormElement>(null);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) =>
     setKeyword(e.target.value);
@@ -21,11 +22,14 @@ export default function SearchInput({ type, className }: SearchInputProps) {
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
-    router.push(`/searchresult?keyword=${keyword}&sort=ascending`);
+    router.push(`/searchresult?keyword=${keyword}&type=all&sort=id-asc`);
+
+    formRef.current && formRef.current.reset();
   };
 
   return (
     <form
+      ref={formRef}
       onSubmit={handleSubmit}
       className={twMerge(
         `relative flex items-center w-max border-blue-50 bg-white-10 rounded-full shadow-outer/down ${SEARCH_INPUT_SIZE[type].form}`,
@@ -55,7 +59,7 @@ const SEARCH_INPUT_SIZE = {
   },
   header: {
     form: 'w-[12.5rem] h-8 border-[.1875rem]',
-    search: 'w-[10.625rem] ml-2 text-[.75rem]',
+    search: 'w-[10.25rem] ml-2 text-[.75rem]',
     submit: 'top-[.3125rem] right-[.3125rem] w-4 h-4 bg-cover',
   },
 } as const;

--- a/src/components/shared/TypeFilters.tsx
+++ b/src/components/shared/TypeFilters.tsx
@@ -15,27 +15,31 @@ interface TypeFiltersProps extends DefaultProps {
 export default function TypeFilters({ usage, lang }: TypeFiltersProps) {
   const router = useRouter();
 
-  const handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
+  const handleFilterClick = (e: React.MouseEvent<HTMLDivElement>) => {
     if (!(e.target instanceof HTMLButtonElement)) return;
 
-    if (e.target instanceof HTMLElement && e.target.dataset.tagName) {
-      const newTypeQuery = e.target.dataset.tagName;
-
-      const searchParams = new URLSearchParams(window.location.search);
-      searchParams.set('type', newTypeQuery);
+    if (e.target instanceof HTMLElement && e.target.dataset.type) {
+      const newTypeQuery = e.target.dataset.type;
 
       usage === 'search' &&
-        router.push(`/searchresult?${searchParams.toString()}`);
+        router.push(`/searchresult?keyword=&type=${newTypeQuery}&sort=id-asc`);
       usage === 'compatibility' &&
-        router.push(`/compatibility?${searchParams.toString()}`);
+        router.push(`/compatibility?type=${newTypeQuery}`);
     }
+  };
+
+  const handleCommonButtonClick = () => {
+    const searchParams = new URLSearchParams(window.location.search);
+    searchParams.set('type', 'all');
+
+    router.push(`/searchresult?${searchParams.toString()}`);
   };
 
   const tagNames = Object.keys(TYPE_TAG_CONTENTS) as PokemonType[];
 
   return (
     <div
-      onClick={handleClick}
+      onClick={handleFilterClick}
       className="flex flex-col items-center max-w-[50.5rem] min-w-[15.75rem] px-4 pt-6 pb-5 border-4 rounded-2xl bg-white-10 shadow-outer/down">
       <h3 className="mb-6 text-2xl font-bold">
         {TYPE_FILTERS_TITLES[lang][usage]}
@@ -48,7 +52,13 @@ export default function TypeFilters({ usage, lang }: TypeFiltersProps) {
         ))}
       </ul>
       {usage === 'search' && (
-        <CommonButton type="viewAll" lang={lang} data-tag-name="all" />
+        <CommonButton
+          type="viewAll"
+          lang={lang}
+          data-type="all"
+          onClick={handleCommonButtonClick}
+          className="mt-2"
+        />
       )}
     </div>
   );

--- a/src/components/shared/TypeTag.tsx
+++ b/src/components/shared/TypeTag.tsx
@@ -27,7 +27,7 @@ export default function TypeTag({
       {usage === 'button' && (
         <button
           type="button"
-          data-tag-name={type}
+          data-type={type}
           className={`hover:scale-110 transition-all ease-out ${tagStyle}`}>
           {tagName}
         </button>

--- a/src/constants/contents.ts
+++ b/src/constants/contents.ts
@@ -40,7 +40,7 @@ export const TYPE_TAG_CONTENTS = {
 } as const;
 
 export const COMMON_BUTTON_CONTENTS = {
-  kr: {
+  ko: {
     area: '출현 장소',
     viewAll: '전체 보기',
     move: '배우는 기술',
@@ -59,7 +59,7 @@ export const COMMON_BUTTON_CONTENTS = {
 } as const;
 
 export const TYPE_FILTERS_TITLES = {
-  kr: {
+  ko: {
     search: '타입별 보기',
     compatibility: '타입별 상성 보기',
   },
@@ -89,224 +89,17 @@ export const INFO_TAG_STAT_CONTENTS = {
 } as const;
 
 export const SELECTED_TYPE_CONTENTS = {
-  kr: '선택한 타입 : ',
+  ko: '선택한 타입 : ',
   en: 'Selected : ',
 } as const;
 
 export const BATTLE_INFO_TITLES = {
-  kr: {
+  ko: {
     attack: '공격을 하는 경우',
     defense: '방어를 하는 경우',
   },
   en: {
     attack: 'You Attack',
     defense: 'You Defense',
-  },
-} as const;
-
-export const BATTLE_INFO_CONTENTS = {
-  normal: {
-    attack: {
-      0.5: ['rock', 'steel'],
-      0: ['ghost'],
-    },
-    defense: {
-      2: ['fighting'],
-      0: ['ghost'],
-    },
-  },
-  fire: {
-    attack: {
-      2: ['grass', 'ice', 'bug', 'steel'],
-      0.5: ['fire', 'water', 'rock', 'dragon'],
-    },
-    defense: {
-      2: ['water', 'ground', 'rock'],
-      0.5: ['fire', 'grass', 'ice', 'bug', 'steel', 'fairy'],
-    },
-  },
-  water: {
-    attack: {
-      2: ['fire', 'ground', 'rock', 'steel'],
-      0.5: ['water', 'grass', 'dragon'],
-    },
-    defense: {
-      2: ['grass', 'electric'],
-      0.5: ['fire', 'water', 'ice', 'steel'],
-    },
-  },
-  grass: {
-    attack: {
-      2: ['water', 'ground', 'rock'],
-      0.5: ['fire', 'grass', 'poison', 'flying', 'bug', 'dragon', 'steel'],
-    },
-    defense: {
-      2: ['fire', 'ice', 'poison', 'flying', 'bug'],
-      0.5: ['water', 'grass', 'electric', 'ground'],
-    },
-  },
-  electric: {
-    attack: {
-      2: ['water', 'flying'],
-      0.5: ['grass', 'dragon', 'electric'],
-      0: ['ground'],
-    },
-    defense: {
-      2: ['ground'],
-      0.5: ['electric', 'flying', 'steel'],
-    },
-  },
-  ice: {
-    attack: {
-      2: ['grass', 'ground', 'flying', 'dragon'],
-      0.5: ['fire', 'water', 'ice', 'steel'],
-    },
-    defense: {
-      2: ['fire', 'fighting', 'rock', 'steel'],
-      0.5: ['ice'],
-    },
-  },
-  psychic: {
-    attack: {
-      2: ['fighting', 'poison'],
-      0.5: ['psychic', 'steel'],
-      0: ['dark'],
-    },
-    defense: {
-      2: ['bug', 'dark', 'ghost'],
-      0.5: ['fighting', 'psychic'],
-    },
-  },
-  dragon: {
-    attack: {
-      2: ['dragon'],
-      0.5: ['steel'],
-      0: ['fairy'],
-    },
-    defense: {
-      2: ['dragon', 'ice', 'fairy'],
-      0.5: ['grass', 'fire', 'water', 'electric'],
-    },
-  },
-  fighting: {
-    attack: {
-      2: ['normal', 'ice', 'ground', 'dark', 'steel'],
-      0.5: ['poison', 'flying', 'psychic', 'bug', 'fairy'],
-      0: ['ghost'],
-    },
-    defense: {
-      2: ['flying', 'psychic', 'fairy'],
-      0.5: ['bug', 'ground', 'dark'],
-    },
-  },
-  flying: {
-    attack: {
-      2: ['grass', 'fighting', 'bug'],
-      0.5: ['electric', 'ground', 'steel'],
-    },
-    defense: {
-      2: ['electric', 'ice', 'ground'],
-      0.5: ['grass', 'fighting', 'bug'],
-      0: ['ground'],
-    },
-  },
-  ground: {
-    attack: {
-      2: ['fire', 'electric', 'poison', 'rock', 'steel'],
-      0.5: ['grass', 'bug'],
-      0: ['flying'],
-    },
-    defense: {
-      2: ['water', 'grass', 'ice'],
-      0.5: ['poison', 'rock'],
-      0: ['electric'],
-    },
-  },
-  rock: {
-    attack: {
-      2: ['fire', 'ice', 'flying', 'bug'],
-      0.5: ['fighting', 'ground', 'steel'],
-    },
-    defense: {
-      2: ['water', 'grass', 'ground', 'steel'],
-      0.5: ['normal', 'fire', 'poison', 'flying'],
-    },
-  },
-  bug: {
-    attack: {
-      2: ['grass', 'psychic', 'dark'],
-      0.5: ['fire', 'fighting', 'ghost', 'flying', 'steel', 'fairy', 'poison'],
-    },
-    defense: {
-      2: ['fire', 'flying', 'rock'],
-      0.5: ['grass', 'fighting', 'ground'],
-    },
-  },
-  ghost: {
-    attack: {
-      2: ['psychic', 'ghost'],
-      0.5: ['dark'],
-      0: ['normal'],
-    },
-    defense: {
-      2: ['ghost', 'dark'],
-      0.5: ['poison', 'bug'],
-      0: ['normal', 'fighting'],
-    },
-  },
-  poison: {
-    attack: {
-      2: ['grass', 'fairy'],
-      0.5: ['poison', 'ground', 'rock', 'ghost'],
-      0: ['steel'],
-    },
-    defense: {
-      2: ['ground', 'psychic'],
-      0.5: ['grass', 'fighting', 'poison', 'bug', 'fairy'],
-    },
-  },
-  dark: {
-    attack: {
-      2: ['psychic', 'ghost'],
-      0.5: ['fighting', 'dark', 'fairy'],
-    },
-    defense: {
-      2: ['fighting', 'bug', 'fairy'],
-      0.5: ['ghost', 'dark'],
-      0: ['psychic'],
-    },
-  },
-  steel: {
-    attack: {
-      2: ['ice', 'rock', 'fairy'],
-      0.5: ['fire', 'water', 'electric', 'steel'],
-    },
-    defense: {
-      2: ['fire', 'fighting', 'ground'],
-      0.5: [
-        'normal',
-        'grass',
-        'ice',
-        'flying',
-        'psychic',
-        'bug',
-        'rock',
-        'dragon',
-        'steel',
-        'fairy',
-      ],
-      0: ['poison'],
-    },
-  },
-  fairy: {
-    attack: {
-      2: ['dragon', 'fighting', 'dark'],
-      0.5: ['fire', 'poison', 'steel'],
-    },
-    defense: {
-      2: ['poison', 'steel'],
-      0.5: ['fighting', 'bug', 'dark'],
-      0: ['dragon'],
-    },
   },
 } as const;

--- a/src/constants/urls.ts
+++ b/src/constants/urls.ts
@@ -3,18 +3,18 @@ export const LOGO_URL = '/assets/img/logo.svg';
 export const LINK_DEFAULT_URL = {
   signin: '/signin',
   signout: '/',
-  searchResult: '/searchresult?keyword=&type=all&sort=id-ascending',
+  searchResult: '/searchresult?keyword=&type=all&sort=id-asc',
   compatibility: '/compatibility?type=normal',
   combinations: '/',
 } as const;
 
 export const SORT_QUERIES = [
-  'id-ascending',
-  'id-descending',
-  'height-ascending',
-  'height-descending',
-  'weight-ascending',
-  'weight-descending',
+  'id-asc',
+  'id-desc',
+  'height-asc',
+  'height-desc',
+  'weight-asc',
+  'weight-desc',
 ] as const;
 
 export const POKEMON_IMAGE_URL = {

--- a/src/constants/values.ts
+++ b/src/constants/values.ts
@@ -1,0 +1,210 @@
+export const GIF_LIMIT = 650;
+
+export const CARDS_LIMIT = 18;
+
+export const BATTLE_INFO_VALUES = {
+  normal: {
+    attack: {
+      0.5: ['rock', 'steel'],
+      0: ['ghost'],
+    },
+    defense: {
+      2: ['fighting'],
+      0: ['ghost'],
+    },
+  },
+  fire: {
+    attack: {
+      2: ['grass', 'ice', 'bug', 'steel'],
+      0.5: ['fire', 'water', 'rock', 'dragon'],
+    },
+    defense: {
+      2: ['water', 'ground', 'rock'],
+      0.5: ['fire', 'grass', 'ice', 'bug', 'steel', 'fairy'],
+    },
+  },
+  water: {
+    attack: {
+      2: ['fire', 'ground', 'rock', 'steel'],
+      0.5: ['water', 'grass', 'dragon'],
+    },
+    defense: {
+      2: ['grass', 'electric'],
+      0.5: ['fire', 'water', 'ice', 'steel'],
+    },
+  },
+  grass: {
+    attack: {
+      2: ['water', 'ground', 'rock'],
+      0.5: ['fire', 'grass', 'poison', 'flying', 'bug', 'dragon', 'steel'],
+    },
+    defense: {
+      2: ['fire', 'ice', 'poison', 'flying', 'bug'],
+      0.5: ['water', 'grass', 'electric', 'ground'],
+    },
+  },
+  electric: {
+    attack: {
+      2: ['water', 'flying'],
+      0.5: ['grass', 'dragon', 'electric'],
+      0: ['ground'],
+    },
+    defense: {
+      2: ['ground'],
+      0.5: ['electric', 'flying', 'steel'],
+    },
+  },
+  ice: {
+    attack: {
+      2: ['grass', 'ground', 'flying', 'dragon'],
+      0.5: ['fire', 'water', 'ice', 'steel'],
+    },
+    defense: {
+      2: ['fire', 'fighting', 'rock', 'steel'],
+      0.5: ['ice'],
+    },
+  },
+  psychic: {
+    attack: {
+      2: ['fighting', 'poison'],
+      0.5: ['psychic', 'steel'],
+      0: ['dark'],
+    },
+    defense: {
+      2: ['bug', 'dark', 'ghost'],
+      0.5: ['fighting', 'psychic'],
+    },
+  },
+  dragon: {
+    attack: {
+      2: ['dragon'],
+      0.5: ['steel'],
+      0: ['fairy'],
+    },
+    defense: {
+      2: ['dragon', 'ice', 'fairy'],
+      0.5: ['grass', 'fire', 'water', 'electric'],
+    },
+  },
+  fighting: {
+    attack: {
+      2: ['normal', 'ice', 'ground', 'dark', 'steel'],
+      0.5: ['poison', 'flying', 'psychic', 'bug', 'fairy'],
+      0: ['ghost'],
+    },
+    defense: {
+      2: ['flying', 'psychic', 'fairy'],
+      0.5: ['bug', 'ground', 'dark'],
+    },
+  },
+  flying: {
+    attack: {
+      2: ['grass', 'fighting', 'bug'],
+      0.5: ['electric', 'ground', 'steel'],
+    },
+    defense: {
+      2: ['electric', 'ice', 'ground'],
+      0.5: ['grass', 'fighting', 'bug'],
+      0: ['ground'],
+    },
+  },
+  ground: {
+    attack: {
+      2: ['fire', 'electric', 'poison', 'rock', 'steel'],
+      0.5: ['grass', 'bug'],
+      0: ['flying'],
+    },
+    defense: {
+      2: ['water', 'grass', 'ice'],
+      0.5: ['poison', 'rock'],
+      0: ['electric'],
+    },
+  },
+  rock: {
+    attack: {
+      2: ['fire', 'ice', 'flying', 'bug'],
+      0.5: ['fighting', 'ground', 'steel'],
+    },
+    defense: {
+      2: ['water', 'grass', 'ground', 'steel'],
+      0.5: ['normal', 'fire', 'poison', 'flying'],
+    },
+  },
+  bug: {
+    attack: {
+      2: ['grass', 'psychic', 'dark'],
+      0.5: ['fire', 'fighting', 'ghost', 'flying', 'steel', 'fairy', 'poison'],
+    },
+    defense: {
+      2: ['fire', 'flying', 'rock'],
+      0.5: ['grass', 'fighting', 'ground'],
+    },
+  },
+  ghost: {
+    attack: {
+      2: ['psychic', 'ghost'],
+      0.5: ['dark'],
+      0: ['normal'],
+    },
+    defense: {
+      2: ['ghost', 'dark'],
+      0.5: ['poison', 'bug'],
+      0: ['normal', 'fighting'],
+    },
+  },
+  poison: {
+    attack: {
+      2: ['grass', 'fairy'],
+      0.5: ['poison', 'ground', 'rock', 'ghost'],
+      0: ['steel'],
+    },
+    defense: {
+      2: ['ground', 'psychic'],
+      0.5: ['grass', 'fighting', 'poison', 'bug', 'fairy'],
+    },
+  },
+  dark: {
+    attack: {
+      2: ['psychic', 'ghost'],
+      0.5: ['fighting', 'dark', 'fairy'],
+    },
+    defense: {
+      2: ['fighting', 'bug', 'fairy'],
+      0.5: ['ghost', 'dark'],
+      0: ['psychic'],
+    },
+  },
+  steel: {
+    attack: {
+      2: ['ice', 'rock', 'fairy'],
+      0.5: ['fire', 'water', 'electric', 'steel'],
+    },
+    defense: {
+      2: ['fire', 'fighting', 'ground'],
+      0.5: [
+        'normal',
+        'grass',
+        'ice',
+        'flying',
+        'psychic',
+        'bug',
+        'rock',
+        'dragon',
+        'steel',
+        'fairy',
+      ],
+      0: ['poison'],
+    },
+  },
+  fairy: {
+    attack: {
+      2: ['dragon', 'fighting', 'dark'],
+      0.5: ['fire', 'poison', 'steel'],
+    },
+    defense: {
+      2: ['poison', 'steel'],
+      0.5: ['fighting', 'bug', 'dark'],
+      0: ['dragon'],
+    },
+  },
+} as const;

--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -1,0 +1,33 @@
+import { useEffect } from 'react';
+import { useQuery } from '@apollo/client';
+import { useSearchParams } from 'next/navigation';
+import { GET_POKEMONS } from '@/api/gql';
+import { CARDS_LIMIT } from '@/constants/values';
+
+function useSearch() {
+  const searchParams = useSearchParams();
+
+  const keyword = searchParams.get('keyword');
+  const type = searchParams.get('type');
+  const [sortKey, sortValue] = searchParams.get('sort')?.split('-') as string[];
+
+  const variables = {
+    limit: CARDS_LIMIT,
+    keyword,
+    type: type === 'all' ? '' : type,
+    sort: { [sortKey]: sortValue },
+    lang: 'ko',
+  };
+
+  const { loading, error, data, refetch } = useQuery(GET_POKEMONS, {
+    variables,
+  });
+
+  useEffect(() => {
+    refetch();
+  }, [searchParams]);
+
+  return { loading, error, pokemonCardsInfo: data?.pokemonCardsInfo };
+}
+
+export default useSearch;

--- a/src/mocks/pokemonDefault.json
+++ b/src/mocks/pokemonDefault.json
@@ -19,7 +19,7 @@
           }
         ],
         "specy": {
-          "krName": [
+          "koName": [
             {
               "name": "이상해꽃"
             }
@@ -62,7 +62,7 @@
               "contents": "Powers up Grass-type moves when the Pokémon’s\nHP is low."
             }
           ],
-          "krName": [
+          "koName": [
             {
               "name": "심록"
             }
@@ -81,7 +81,7 @@
               "contents": "Boosts the Pokémon’s Speed stat in harsh sunlight."
             }
           ],
-          "krName": [
+          "koName": [
             {
               "name": "엽록소"
             }
@@ -131,7 +131,7 @@
                 ]
               }
             ],
-            "krName": [
+            "koName": [
               {
                 "name": "이상해씨"
               }
@@ -184,7 +184,7 @@
                 ]
               }
             ],
-            "krName": [
+            "koName": [
               {
                 "name": "이상해꽃"
               }
@@ -209,7 +209,7 @@
                 ]
               }
             ],
-            "krName": [
+            "koName": [
               {
                 "name": "이상해풀"
               }

--- a/src/mocks/pokemonException.json
+++ b/src/mocks/pokemonException.json
@@ -19,7 +19,7 @@
           }
         ],
         "specy": {
-          "krName": [
+          "koName": [
             {
               "name": "드니차"
             }
@@ -42,7 +42,7 @@
         "info": {
           "enName": "thermal-exchange",
           "description": [],
-          "krName": []
+          "koName": []
         }
       },
       {
@@ -57,7 +57,7 @@
               "contents": "The Pokémon gradually regains HP in a hailstorm."
             }
           ],
-          "krName": [
+          "koName": [
             {
               "name": "아이스바디"
             }
@@ -107,7 +107,7 @@
                 ]
               }
             ],
-            "krName": [
+            "koName": [
               {
                 "name": "드니차"
               }
@@ -132,7 +132,7 @@
                 ]
               }
             ],
-            "krName": [
+            "koName": [
               {
                 "name": "드니꽁"
               }
@@ -157,7 +157,7 @@
                 ]
               }
             ],
-            "krName": [
+            "koName": [
               {
                 "name": "드닐레이브"
               }

--- a/src/mocks/pokemons.json
+++ b/src/mocks/pokemons.json
@@ -17,7 +17,7 @@
           }
         ],
         "specy": {
-          "krName": [
+          "koName": [
             {
               "name": "이상해씨"
             }
@@ -40,7 +40,7 @@
           }
         ],
         "specy": {
-          "krName": [
+          "koName": [
             {
               "name": "이상해풀"
             }
@@ -63,7 +63,7 @@
           }
         ],
         "specy": {
-          "krName": [
+          "koName": [
             {
               "name": "이상해꽃"
             }
@@ -81,7 +81,7 @@
           }
         ],
         "specy": {
-          "krName": [
+          "koName": [
             {
               "name": "파이리"
             }
@@ -99,7 +99,7 @@
           }
         ],
         "specy": {
-          "krName": [
+          "koName": [
             {
               "name": "리자드"
             }
@@ -122,7 +122,7 @@
           }
         ],
         "specy": {
-          "krName": [
+          "koName": [
             {
               "name": "리자몽"
             }
@@ -140,7 +140,7 @@
           }
         ],
         "specy": {
-          "krName": [
+          "koName": [
             {
               "name": "꼬부기"
             }
@@ -158,7 +158,7 @@
           }
         ],
         "specy": {
-          "krName": [
+          "koName": [
             {
               "name": "어니부기"
             }
@@ -176,7 +176,7 @@
           }
         ],
         "specy": {
-          "krName": [
+          "koName": [
             {
               "name": "거북왕"
             }
@@ -194,7 +194,7 @@
           }
         ],
         "specy": {
-          "krName": [
+          "koName": [
             {
               "name": "캐터피"
             }
@@ -212,7 +212,7 @@
           }
         ],
         "specy": {
-          "krName": [
+          "koName": [
             {
               "name": "단데기"
             }
@@ -235,7 +235,7 @@
           }
         ],
         "specy": {
-          "krName": [
+          "koName": [
             {
               "name": "버터플"
             }
@@ -258,7 +258,7 @@
           }
         ],
         "specy": {
-          "krName": [
+          "koName": [
             {
               "name": "뿔충이"
             }
@@ -281,7 +281,7 @@
           }
         ],
         "specy": {
-          "krName": [
+          "koName": [
             {
               "name": "딱충이"
             }
@@ -304,7 +304,7 @@
           }
         ],
         "specy": {
-          "krName": [
+          "koName": [
             {
               "name": "독침붕"
             }
@@ -327,7 +327,7 @@
           }
         ],
         "specy": {
-          "krName": [
+          "koName": [
             {
               "name": "구구"
             }
@@ -350,7 +350,7 @@
           }
         ],
         "specy": {
-          "krName": [
+          "koName": [
             {
               "name": "피죤"
             }
@@ -373,7 +373,7 @@
           }
         ],
         "specy": {
-          "krName": [
+          "koName": [
             {
               "name": "피죤투"
             }

--- a/src/types/common.d.ts
+++ b/src/types/common.d.ts
@@ -2,7 +2,7 @@ export interface DefaultProps {
   className?: string;
 }
 
-export type Lang = 'kr' | 'en';
+export type Lang = 'ko' | 'en';
 
 export type PokemonType =
   | 'normal'

--- a/src/types/data.d.ts
+++ b/src/types/data.d.ts
@@ -6,7 +6,7 @@ export interface RawPokemonCardInfo {
   types: {
     type: { name: string };
   }[];
-  specy: { krName: { name: string }[] };
+  specy: { koName: { name: string }[] };
 }
 
 export type RawPokemonCardsInfo = RawPokemonCardInfo[];
@@ -18,7 +18,7 @@ export interface RawPokemonDetailInfo {
     height: number;
     weight: number;
     types: { type: { name: string } }[];
-    specy: { krName: { name: string }[] };
+    specy: { koName: { name: string }[] };
   }[];
   feature: { contents: string }[];
   description: { contents: string }[] | [];
@@ -27,7 +27,7 @@ export interface RawPokemonDetailInfo {
     info: {
       enName: string;
       description: { contents: string }[] | [];
-      krName: { name: string }[] | [];
+      koName: { name: string }[] | [];
     };
   }[];
   stats: { value: number }[];
@@ -35,7 +35,7 @@ export interface RawPokemonDetailInfo {
     specy: {
       id: number;
       enName: string;
-      krName: { name: string }[];
+      koName: { name: string }[];
       pokemonInfo: { types: { type: { name: string } }[] }[];
     }[];
   }[];

--- a/src/utils/convertContents.ts
+++ b/src/utils/convertContents.ts
@@ -4,9 +4,9 @@ export const convertContents = (
   contents: { contents: string }[],
   lang: Lang,
 ) => {
-  const [krContents, enContents] = contents;
+  const [koContents, enContents] = contents;
 
-  return lang === 'kr'
-    ? krContents.contents.replaceAll('\n', ' ')
+  return lang === 'ko'
+    ? koContents.contents.replaceAll('\n', ' ')
     : enContents.contents.replaceAll('\n', ' ');
 };

--- a/src/utils/convertInfoTagName.ts
+++ b/src/utils/convertInfoTagName.ts
@@ -2,7 +2,7 @@ import { INFO_TAG_STAT_CONTENTS } from '@/constants/contents';
 import { Lang, PokemonStat } from '@/types/common';
 
 export const convertInfoTagName = (stat: PokemonStat, lang: Lang) => {
-  if (lang === 'kr') return INFO_TAG_STAT_CONTENTS[stat];
+  if (lang === 'ko') return INFO_TAG_STAT_CONTENTS[stat];
 
   switch (stat) {
     case 'hp':

--- a/src/utils/convertName.ts
+++ b/src/utils/convertName.ts
@@ -2,6 +2,6 @@ import { Lang } from '@/types/common';
 
 export const convertName = (
   enName: string,
-  krName: { name: string }[],
+  koName: { name: string }[],
   lang: Lang,
-) => (lang === 'kr' ? krName[0].name : enName);
+) => (lang === 'ko' ? koName[0].name : enName);

--- a/src/utils/convertTypeTagName.ts
+++ b/src/utils/convertTypeTagName.ts
@@ -2,6 +2,6 @@ import { TYPE_TAG_CONTENTS } from '@/constants/contents';
 import { Lang, PokemonType } from '@/types/common';
 
 export const convertTypeTagName = (type: PokemonType, lang: Lang) =>
-  lang === 'kr'
+  lang === 'ko'
     ? TYPE_TAG_CONTENTS[type]
     : type.charAt(0).toUpperCase() + type.slice(1);

--- a/src/utils/getImageInfo.ts
+++ b/src/utils/getImageInfo.ts
@@ -1,13 +1,15 @@
 import { POKEMON_IMAGE_URL } from '@/constants/urls';
+import { GIF_LIMIT } from '@/constants/values';
 
-export const getImageInfo = async (id: number) => {
-  const gifUrl = `${POKEMON_IMAGE_URL.gif}${id}.gif`;
-  const pngUrl = `${POKEMON_IMAGE_URL.png}${id}.png`;
-
-  const response = await fetch(gifUrl);
+export const getImageInfo = (id: number) => {
+  const imgUrl =
+    id < GIF_LIMIT
+      ? `${POKEMON_IMAGE_URL.gif}${id}.gif`
+      : `${POKEMON_IMAGE_URL.png}${id}.png`;
+  const format = id < GIF_LIMIT ? 'gif' : 'png';
 
   return {
-    imgUrl: response.ok ? gifUrl : pngUrl,
-    format: response.ok ? 'gif' : 'png',
+    imgUrl,
+    format,
   } as const;
 };

--- a/src/utils/processCardsInfo.ts
+++ b/src/utils/processCardsInfo.ts
@@ -3,9 +3,9 @@ import { RawPokemonCardsInfo } from '@/types/data';
 import { convertName } from './convertName';
 
 export const processCardsInfo = (info: RawPokemonCardsInfo, lang: Lang) => {
-  const newCardsInfo = info.map(({ enName, id, types, specy: { krName } }) => ({
+  const newCardsInfo = info.map(({ enName, id, types, specy: { koName } }) => ({
     id,
-    name: convertName(enName, krName, lang),
+    name: convertName(enName, koName, lang),
     types: types.map(({ type }) => type.name) as PokemonType[],
     isCatched: false,
   }));

--- a/src/utils/processDetailInfo.ts
+++ b/src/utils/processDetailInfo.ts
@@ -12,7 +12,7 @@ export const processDetailInfo = (info: RawPokemonDetailInfo, lang: Lang) => {
     height,
     weight,
     types,
-    specy: { krName },
+    specy: { koName },
   } = basicInfo[0];
   const { specy } = evolutionChain[0];
 
@@ -28,10 +28,10 @@ export const processDetailInfo = (info: RawPokemonDetailInfo, lang: Lang) => {
     ? abilities.map((abilitiy) => {
         const {
           isHidden,
-          info: { enName, description, krName },
+          info: { enName, description, koName },
         } = abilitiy;
 
-        const name = convertName(enName, krName, lang);
+        const name = convertName(enName, koName, lang);
         const newDescription = convertContents(description, lang);
 
         return { isHidden, name, description: newDescription };
@@ -48,9 +48,9 @@ export const processDetailInfo = (info: RawPokemonDetailInfo, lang: Lang) => {
       ? specy
           .sort((a, b) => a.id - b.id)
           .map((info) => {
-            const { id, enName, krName, pokemonInfo } = info;
+            const { id, enName, koName, pokemonInfo } = info;
 
-            const name = convertName(enName, krName, lang);
+            const name = convertName(enName, koName, lang);
             const newTypes = pokemonInfo[0].types.map(
               (type) => type.type.name,
             ) as PokemonType[];
@@ -61,7 +61,7 @@ export const processDetailInfo = (info: RawPokemonDetailInfo, lang: Lang) => {
 
   return {
     id,
-    name: convertName(enName, krName, lang),
+    name: convertName(enName, koName, lang),
     types: types.map(({ type }) => type.name) as PokemonType[],
     feature: newFeature,
     description: newDescription,


### PR DESCRIPTION
## PR Type
- [x] FEAT: 새로운 기능 구현
- [ ] ADD : 에셋 파일 추가
- [x] FIX: 버그 수정
- [ ] DOCS: 문서 추가 및 수정
- [ ] STYLE: 포맷팅 변경
- [x] REFACTOR: 코드 리팩토링
- [ ] TEST: 테스트 관련
- [ ] DEPLOY: 배포 관련
- [ ] CONF: 빌드, 환경 설정
- [x] CHORE: 기타 작업

## Abstracts
* SearchResult 페이지를 구현합니다.

## Description
* 작업 내용
- [x] SearchResult 페이지 구현
  - [x] Apollo Client 연결
  - [x] 검색 요청 쿼리 작성
  - [x] 커스텀 훅 `useSearch` 구현
- [x] 기본 값 관련 상수 추가
- [x] PokemonImage 컴포넌트 리팩토링
  - [x] 유틸 함수 getImaeInfo 리팩토링
- [x] 리스트 렌더링 관련 경고 해결
- [x] 기존 컴포넌트의 스타일링 오류 수정 

* 구현 결과 이미지
![타입별](https://github.com/My-Pokedex/my-pokedex-client/assets/101828759/b7891002-f229-4976-9834-774efbe26b8f)

## Discussion
* 로딩 시 보여줄 컴포넌트 추가 구현 필요합니다.
* 무한 스크롤 기능 추가 구현 필요합니다.
* 커스텀 훅 `useSearch`의 리팩토링이 필요합니다.

---
Close #53 
