### PR TITLE
✨ 무한 스크롤 기능 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,9 +18,11 @@
         "postcss": "8.4.27",
         "react": "18.2.0",
         "react-dom": "18.2.0",
+        "react-uuid": "^2.0.0",
         "tailwind-merge": "^1.14.0",
         "tailwindcss": "3.3.3",
-        "typescript": "5.1.6"
+        "typescript": "5.1.6",
+        "zustand": "^4.4.1"
       },
       "devDependencies": {
         "@storybook/addon-essentials": "^7.2.2",
@@ -15536,6 +15538,12 @@
         }
       }
     },
+    "node_modules/react-uuid": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/react-uuid/-/react-uuid-2.0.0.tgz",
+      "integrity": "sha512-FNUH/8WR/FEtx0Bu6gmt1eONfc413hhvrEXFWUSFGvznUhI4dYoVZA09p7JHoTpnM4WC2D/bG2YSxGKXF4oVLg==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info."
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -18042,6 +18050,14 @@
         }
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/util": {
       "version": "0.12.5",
       "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
@@ -18729,6 +18745,33 @@
       "integrity": "sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.4.1.tgz",
+      "integrity": "sha512-QCPfstAS4EBiTQzlaGP1gmorkh/UL1Leaj2tdj+zZCZ/9bm0WS7sI2wnfD5lpOszFqWJ1DcPnGoY8RDL61uokw==",
+      "dependencies": {
+        "use-sync-external-store": "1.2.0"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     }
   },
@@ -29850,6 +29893,11 @@
         "tslib": "^2.0.0"
       }
     },
+    "react-uuid": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/react-uuid/-/react-uuid-2.0.0.tgz",
+      "integrity": "sha512-FNUH/8WR/FEtx0Bu6gmt1eONfc413hhvrEXFWUSFGvznUhI4dYoVZA09p7JHoTpnM4WC2D/bG2YSxGKXF4oVLg=="
+    },
     "read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -31710,6 +31758,12 @@
         "tslib": "^2.0.0"
       }
     },
+    "use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "requires": {}
+    },
     "util": {
       "version": "0.12.5",
       "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
@@ -32232,6 +32286,14 @@
       "version": "3.21.4",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.21.4.tgz",
       "integrity": "sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw=="
+    },
+    "zustand": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.4.1.tgz",
+      "integrity": "sha512-QCPfstAS4EBiTQzlaGP1gmorkh/UL1Leaj2tdj+zZCZ/9bm0WS7sI2wnfD5lpOszFqWJ1DcPnGoY8RDL61uokw==",
+      "requires": {
+        "use-sync-external-store": "1.2.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,9 +21,11 @@
     "postcss": "8.4.27",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "react-uuid": "^2.0.0",
     "tailwind-merge": "^1.14.0",
     "tailwindcss": "3.3.3",
-    "typescript": "5.1.6"
+    "typescript": "5.1.6",
+    "zustand": "^4.4.1"
   },
   "devDependencies": {
     "@storybook/addon-essentials": "^7.2.2",

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -2,7 +2,33 @@ import { ApolloClient, InMemoryCache } from '@apollo/client';
 
 const client = new ApolloClient({
   uri: 'https://beta.pokeapi.co/graphql/v1beta',
-  cache: new InMemoryCache(),
+  cache: new InMemoryCache({
+    typePolicies: {
+      Query: {
+        fields: {
+          pokemon_v2_pokemon: {
+            read(existing) {
+              return existing;
+            },
+            merge(existing = [], incoming = []) {
+              const result = [...existing, ...incoming].reduce((acc, cur) => {
+                if (
+                  acc.findIndex(
+                    ({ __ref }: { __ref: string }) => __ref === cur.__ref,
+                  ) === -1
+                )
+                  acc.push(cur);
+
+                return acc;
+              }, []);
+
+              return result;
+            },
+          },
+        },
+      },
+    },
+  }),
 });
 
 export default client;

--- a/src/api/gql/getList.ts
+++ b/src/api/gql/getList.ts
@@ -7,6 +7,7 @@ const GET_LIST = gql`
     $type: String!
     $sort: [pokemon_v2_pokemon_order_by!]
     $lang: String!
+    $offset: Int!
   ) {
     pokemonCardsInfo: pokemon_v2_pokemon(
       where: {
@@ -29,6 +30,7 @@ const GET_LIST = gql`
       }
       limit: $limit
       order_by: $sort
+      offset: $offset
     ) {
       enName: name
       id: pokemon_species_id

--- a/src/components/features/NavBar/NavBar.tsx
+++ b/src/components/features/NavBar/NavBar.tsx
@@ -1,8 +1,13 @@
+'use client';
+
+import { usePageStore } from '@/stores';
 import { twMerge } from 'tailwind-merge';
 import NavLink from './NavLink';
 import { DefaultProps } from '@/types/common';
 
 export default function NavBar({ className }: DefaultProps) {
+  const { resetPage } = usePageStore();
+
   return (
     <nav
       className={twMerge(
@@ -14,7 +19,7 @@ export default function NavBar({ className }: DefaultProps) {
           <NavLink destination="signin" />
         </li>
         <li>
-          <NavLink destination="searchResult" />
+          <NavLink destination="searchResult" onClick={resetPage} />
         </li>
         <li>
           <NavLink destination="compatibility" />

--- a/src/components/features/NavBar/NavLink.tsx
+++ b/src/components/features/NavBar/NavLink.tsx
@@ -7,14 +7,16 @@ type Destination = 'signin' | 'signout' | 'searchResult' | 'compatibility';
 
 interface NavLinkProps extends DefaultProps {
   destination: Destination;
+  onClick?: React.MouseEventHandler<HTMLAnchorElement>;
 }
 
-export default function NavLink({ destination }: NavLinkProps) {
+export default function NavLink({ destination, onClick }: NavLinkProps) {
   const textSize = destination === 'signout' ? 'text-base' : 'text-lg';
 
   return (
     <Link
       href={LINK_DEFAULT_URL[destination]}
+      onClick={onClick}
       className={`block w-[6rem] h-[3.25rem] leading-[2.75rem] border-4 rounded-[.625rem] bg-navy-10 font-bold text-white-10 text-center shadow-outer/rightdown ${textSize}`}>
       {NAV_LINK_CONTENTS[destination]}
     </Link>

--- a/src/components/features/PokemonCards/PokemonCards.tsx
+++ b/src/components/features/PokemonCards/PokemonCards.tsx
@@ -12,27 +12,34 @@ interface PokemonCardsProps extends DefaultProps {
 }
 
 export default function PokemonCards({ lang }: PokemonCardsProps) {
-  const { loading, error, pokemonCardsInfo } = useSearch();
+  const { loading, error, observerTarget, pokemonCardsInfo } = useSearch();
 
-  if (loading) return <Loading className="mb-9" />;
+  if (loading && !pokemonCardsInfo) return <Loading className="mb-9" />;
   if (error) return notFound();
   if (!pokemonCardsInfo.length) return <NoResults />;
 
   const processed = processCardsInfo(pokemonCardsInfo, lang);
 
   return (
-    <div
-      className={
-        'grid grid-cols-3 gap-4 max-3cards:grid-cols-2 max-2cards:grid-cols-1 mb-[5rem]'
-      }>
-      <h2 className="sr-only">검색 결과</h2>
-      {processed.map((pokemonCardInfo) => (
-        <PokemonCard
-          key={pokemonCardInfo.id}
-          pokemonCardInfo={pokemonCardInfo}
-          lang={lang}
-        />
-      ))}
-    </div>
+    <>
+      <div
+        className={
+          'grid grid-cols-3 gap-4 max-3cards:grid-cols-2 max-2cards:grid-cols-1 mb-6]'
+        }>
+        <h2 className="sr-only">검색 결과</h2>
+        {processed.map((pokemonCardInfo) => (
+          <PokemonCard
+            key={pokemonCardInfo.id}
+            pokemonCardInfo={pokemonCardInfo}
+            lang={lang}
+          />
+        ))}
+      </div>
+      {loading ? (
+        <div className="w-full h-12 my-8 bg-no-repeat bg-contain bg-center bg-[url('/assets/img/loading.gif')]" />
+      ) : (
+        <div ref={observerTarget} className="w-full h-12 my-8" />
+      )}
+    </>
   );
 }

--- a/src/components/shared/SearchInput.tsx
+++ b/src/components/shared/SearchInput.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useRef } from 'react';
 import { useRouter } from 'next/navigation';
+import { usePageStore } from '@/stores';
 import { twMerge } from 'tailwind-merge';
 import { DefaultProps } from '@/types/common';
 
@@ -13,6 +14,7 @@ interface SearchInputProps extends DefaultProps {
 
 export default function SearchInput({ type, className }: SearchInputProps) {
   const router = useRouter();
+  const { resetPage } = usePageStore();
   const [keyword, setKeyword] = useState('');
   const formRef = useRef<HTMLFormElement>(null);
 
@@ -22,6 +24,7 @@ export default function SearchInput({ type, className }: SearchInputProps) {
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
+    resetPage();
     router.push(`/searchresult?keyword=${keyword}&type=all&sort=id-asc`);
 
     formRef.current && formRef.current.reset();

--- a/src/components/shared/TypeFilters.tsx
+++ b/src/components/shared/TypeFilters.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
+import { usePageStore } from '@/stores';
 import { TypeTag, CommonButton } from '@/components';
 import { DefaultProps, Lang, PokemonType } from '@/types/common';
 import { TYPE_TAG_CONTENTS, TYPE_FILTERS_TITLES } from '@/constants/contents';
@@ -14,6 +15,7 @@ interface TypeFiltersProps extends DefaultProps {
 
 export default function TypeFilters({ usage, lang }: TypeFiltersProps) {
   const router = useRouter();
+  const { resetPage } = usePageStore();
 
   const handleFilterClick = (e: React.MouseEvent<HTMLDivElement>) => {
     if (!(e.target instanceof HTMLButtonElement)) return;
@@ -21,8 +23,12 @@ export default function TypeFilters({ usage, lang }: TypeFiltersProps) {
     if (e.target instanceof HTMLElement && e.target.dataset.type) {
       const newTypeQuery = e.target.dataset.type;
 
-      usage === 'search' &&
+      if (usage === 'search') {
+        resetPage();
+
         router.push(`/searchresult?keyword=&type=${newTypeQuery}&sort=id-asc`);
+      }
+
       usage === 'compatibility' &&
         router.push(`/compatibility?type=${newTypeQuery}`);
     }

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -1,0 +1,3 @@
+import usePageStore from './pageStore';
+
+export { usePageStore };

--- a/src/stores/pageStore.ts
+++ b/src/stores/pageStore.ts
@@ -1,0 +1,15 @@
+import { create } from 'zustand';
+
+interface PageState {
+  page: number;
+  increasePage: () => void;
+  resetPage: () => void;
+}
+
+const usePageStore = create<PageState>((set) => ({
+  page: 0,
+  increasePage: () => set((state) => ({ page: state.page + 1 })),
+  resetPage: () => set(() => ({ page: 0 })),
+}));
+
+export default usePageStore;


### PR DESCRIPTION
## PR Type
- [x] FEAT: 새로운 기능 구현
- [ ] ADD : 에셋 파일 추가
- [ ] FIX: 버그 수정
- [ ] DOCS: 문서 추가 및 수정
- [ ] STYLE: 포맷팅 변경
- [ ] REFACTOR: 코드 리팩토링
- [ ] TEST: 테스트 관련
- [ ] DEPLOY: 배포 관련
- [x] CONF: 빌드, 환경 설정
- [ ] CHORE: 기타 작업

## Abstracts
* 무한 스크롤 기능을 구현합니다.
* zustand, uuid 패키지를 설치하여 적용니다.

## Description
* 작업 내용
- [x] 무한 스크롤 기능 구현
  - [x] useSearch 훅에 로직 추가
  - [x] PokemonCards 컴포넌트에 로딩 스피너 추가  
  - [x] Apollo Client의 MemoryCache 객체 옵션 추가
  - [x] 요청 쿼리에 offset 변수 추가 
- [x] zustand 패키지 설치
- [x] 현재 페이지 값 관련 store 생성 및 기존 컴포넌트에 적용  

* 구현 결과 이미지
![스크롤](https://github.com/My-Pokedex/my-pokedex-client/assets/101828759/9185005c-f39b-4f2a-9f1f-b78292979076)


## Discussion
* 무한 스크롤 중복 호출 이슈
  : throttle 로직을 적용하면 해결할 수 있을 듯합니다.
* 페이지 이동 후 뒤로 가기 시 스크롤 값 저장
  : 추후 sessionStorage를 사용하여 추가 구현이 필요합니다.
* `useQuery` 훅의 loading state 관련 이슈
  : 첫 fetch 시와 추가 fetch 시의 loading state를 다르게 설정할 수 있는 방법이 있는지 리서치가 필요합니다.
  : `useLazyQuery` 훅을 사용해보았지만 정상적으로 동작하지 않아서 useQuery 훅의 `fetchMore`, `refetch` 메서드로 해결하였습니다.
  : loading state 관련 이슈는 PokemonCards 컴포넌트에서 조건 처리를 해주는 방식으로 임시 해결하였지만, 추후 리팩토링이 필요합니다.

---
Close #70 
